### PR TITLE
Fix translation loading in case of moved installation dir

### DIFF
--- a/lib/Games/FrozenBubble/Stuff.pm
+++ b/lib/Games/FrozenBubble/Stuff.pm
@@ -1,13 +1,13 @@
 package Games::FrozenBubble::Stuff;
 
 use Games::FrozenBubble::CStuff;
-# use Games::FrozenBubble::Config;
+use Games::FrozenBubble::Config;
 use Locale::Maketext::Simple;
 use File::ShareDir qw(dist_dir);
 
-Locale::Maketext::Simple->import(Path => dist_dir('Games-FrozenBubble')."/locale", Style => 'gettext', Export => 'gettext');
+Locale::Maketext::Simple->import(Path => "$FPATH/locale", Style => 'gettext', Export => 'gettext');
 ###passing language to Locale::Maketext::Simple
-my ($lang) = split(':', $ENV{LANGUAGE});
+my ($lang) = split(':', $ENV{LANGUAGE} || $ENV{LANG});
 gettext_lang($lang);
 
 use vars qw(@ISA @EXPORT $FPATH $FLPATH $FBHOME $FBLEVELS $colourblind %POS_1P %POS_2P %POS_MP $BUBBLE_SIZE $ROW_SIZE


### PR DESCRIPTION
Fix file loading and also detection of language. ENV{LANGUAGE} seems deprecated for openSUSE. LANG is used instead.
