### PR TITLE
Replace broken bugtracker with a working one

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -62,7 +62,7 @@ My::Builder->new(
     meta_merge           => {
         resources => {
             repository => 'http://github.com/kthakore/frozen-bubble',
-            bugtracker => 'http://sdlperl.ath.cx/projects/SDLPerl/query?component=FrozenBubble',
+            bugtracker => 'https://github.com/kthakore/frozen-bubble/issues',
         },
     },
     module_name => 'Games::FrozenBubble',


### PR DESCRIPTION
You might prefer to link to the RT queue for the module or to some other bug tracker that replaced the one that was linked.  This is in part notification that the current bugtracker link is broken.
