### PR TITLE
Check the return value of the setgid and setuid functions

### DIFF
--- a/server/tools.c
+++ b/server/tools.c
@@ -261,8 +261,16 @@ void daemonize() {
         if (user_to_switch != NULL) {
                 struct passwd* user = getpwnam(user_to_switch);
                 if (user) {
-                        setgid(user->pw_gid);
-                        setuid(user->pw_uid);
+                        if(setgid(user->pw_gid) == -1)
+                        {
+                                l2(OUTPUT_TYPE_ERROR, "Cannot set the GID to %d: %s", user->pw_gid, strerror(errno));
+                                exit(EXIT_FAILURE);
+                        }
+                        if(setuid(user->pw_uid) == -1)
+                        {
+                                l2(OUTPUT_TYPE_ERROR, "Cannot set the UID to %d: %s", user->pw_uid, strerror(errno));
+                                exit(EXIT_FAILURE);
+                        }
                 } else {
                         l2(OUTPUT_TYPE_ERROR, "Cannot switch user to %s: %s", user_to_switch, strerror(errno));
                 }


### PR DESCRIPTION
Without checking the value of the setgid and setuid functions, an error happens while building:
```
$ ./Build
cc -I/usr/lib64/perl5/CORE -fPIC -g -Wall -Werror -pipe -Iserver -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -lglib-2.0 -c -D_REENTRANT -D_GNU_SOURCE -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2 -O2 -fPIC -o server/fb-server.o server/fb-server.c
cc -I/usr/lib64/perl5/CORE -fPIC -g -Wall -Werror -pipe -Iserver -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -lglib-2.0 -c -D_REENTRANT -D_GNU_SOURCE -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2 -O2 -fPIC -o server/log.o server/log.c
cc -I/usr/lib64/perl5/CORE -fPIC -g -Wall -Werror -pipe -Iserver -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -lglib-2.0 -c -D_REENTRANT -D_GNU_SOURCE -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2 -O2 -fPIC -o server/tools.o server/tools.c
server/tools.c: In function ‘daemonize’:
server/tools.c:264:25: error: ignoring return value of ‘setgid’, declared with attribute warn_unused_result [-Werror=unused-result]
                         setgid(user->pw_gid);
                         ^
server/tools.c:265:25: error: ignoring return value of ‘setuid’, declared with attribute warn_unused_result [-Werror=unused-result]
                         setuid(user->pw_uid);
                         ^
cc1: all warnings being treated as errors
error building server/tools.o from 'server/tools.c' at /usr/share/perl5/ExtUtils/CBuilder/Base.pm line 173.
```

Moreover, it is a grave security error to omit checking for a failure return from the setuid function [1].

So, this is what I fixed.

Please accept my pull request.
Thank you.
Best regards.

ChangeLog:
* server/tools.c(daemonize): Modified file (check the return value of the setgid function).
* server/tools.c(daemonize): Modified file (check the return value of the setuid function).

[1] http://man7.org/linux/man-pages/man2/setuid.2.html